### PR TITLE
Added nested search in search filter backend

### DIFF
--- a/examples/factories/blog_post.py
+++ b/examples/factories/blog_post.py
@@ -61,7 +61,6 @@ class CommentAuthorFactory(Factory):
 class CommentFactory(Factory):
     """Comment factory."""
 
-    author = CommentAuthorFactory.create()
     tag = FuzzyChoice([
         'Elastic',
         'MongoDB',
@@ -72,6 +71,11 @@ class CommentFactory(Factory):
     ])
     content = Faker('text')
     created_at = Faker('date')
+
+    @factory.post_generation
+    def author(obj, create, extracted, **kwargs):
+        if create:
+            obj.author = CommentAuthorFactory.create()
 
     class Meta(object):
         model = Comment

--- a/examples/factories/blog_post.py
+++ b/examples/factories/blog_post.py
@@ -10,6 +10,8 @@ from .elasticsearch_dsl_factory import ElasticsearchFactory
 
 __all__ = (
     'Comment',
+    'CommentAuthor',
+    'CommentAuthorFactory',
     'CommentFactory',
     'PostFactory',
     'ManyViewsPostFactory',
@@ -25,6 +27,13 @@ class Serializable(object):
         return self.__dict__
 
 
+class CommentAuthor(Serializable):
+    """Comment Author model (we need one for factories)."""
+
+    def __init__(self, *args, **kwargs):
+        self.name = kwargs.get('name')
+        self.age = kwargs.get('age')
+
 class Comment(Serializable):
     """Comment model (we need one for factories)."""
 
@@ -34,7 +43,6 @@ class Comment(Serializable):
         self.content = kwargs.get('content')
         self.created_at = kwargs.get('created_at')
 
-
 class Tag(Serializable):
     """Tag model (we need one for factories)."""
 
@@ -42,10 +50,18 @@ class Tag(Serializable):
         self.name = kwargs.get('name')
 
 
+class CommentAuthorFactory(Factory):
+
+    name = Faker('name')
+    age = Faker('pyint', min_value=10, max_value=40)
+
+    class Meta:
+        model = CommentAuthor
+
 class CommentFactory(Factory):
     """Comment factory."""
 
-    author = Faker('name')
+    author = CommentAuthorFactory.create()
     tag = FuzzyChoice([
         'Elastic',
         'MongoDB',

--- a/examples/schema/meta/post.py
+++ b/examples/schema/meta/post.py
@@ -299,7 +299,8 @@ class AbstractPostDocumentMeta:
                 "tag",
                 {
                     "content": {
-                        "field": "content.raw"
+                        "field": "content.raw",
+                        "boost": 3
                     }
                 }
             ]
@@ -311,11 +312,6 @@ class AbstractPostDocumentMeta:
                     "name": {
                         "field": "name.raw",
                         "boost": 2
-                    }
-                },
-                {
-                    "age": {
-                        "field": "age"
                     }
                 }
             ]

--- a/examples/schema/meta/post.py
+++ b/examples/schema/meta/post.py
@@ -296,13 +296,27 @@ class AbstractPostDocumentMeta:
         "comments": {
             "path": "comments",
             "fields": [
-                "author", 
+                "tag",
                 {
-                    "field": "tag"
+                    "content": {
+                        "field": "content.raw"
+                    }
+                }
+            ]
+        },
+        "author": {
+            "path": "comments.author",
+            "fields": [
+                {
+                    "name": {
+                        "field": "name.raw",
+                        "boost": 2
+                    }
                 },
                 {
-                    "field": "content", 
-                    "boost": 4
+                    "age": {
+                        "field": "age"
+                    }
                 }
             ]
         }

--- a/examples/schema/meta/post.py
+++ b/examples/schema/meta/post.py
@@ -291,3 +291,19 @@ class AbstractPostDocumentMeta:
 
         "i_do_not_exist": "i_do_not_exist",
     }
+
+    search_nested_fields = {
+        "comments": {
+            "path": "comments",
+            "fields": [
+                "author", 
+                {
+                    "field": "tag"
+                },
+                {
+                    "field": "content", 
+                    "boost": 4
+                }
+            ]
+        }
+    }

--- a/examples/schema/read_only_post.py
+++ b/examples/schema/read_only_post.py
@@ -12,6 +12,7 @@ from graphene_elastic.filter_backends import (
     DefaultOrderingFilterBackend,
     HighlightFilterBackend,
     SourceFilterBackend,
+    SearchFilterBackend
 )
 
 from search_index.documents import ReadOnlyPost as ReadOnlyPostDocument
@@ -36,6 +37,7 @@ class ReadOnlyPost(ElasticsearchObjectType):
             HighlightFilterBackend,
             SourceFilterBackend,
             FacetedSearchFilterBackend,
+            SearchFilterBackend,
             # CustomFilterBackend,
             OrderingFilterBackend,
             DefaultOrderingFilterBackend,

--- a/examples/search_index/documents/address.py
+++ b/examples/search_index/documents/address.py
@@ -17,55 +17,52 @@ try:
     from elasticsearch import logger
 except ImportError:
     import logging
+
     logger = logging.getLogger(__name__)
 
-__all__ = (
-    'Address',
-)
+__all__ = ("Address",)
 
 connections.create_connection(**ELASTICSEARCH_CONNECTION)
 
 
 html_strip = analyzer(
-    'html_strip',
+    "html_strip",
     tokenizer="standard",
     filter=["lowercase", "stop", "snowball"],
-    char_filter=["html_strip"]
+    char_filter=["html_strip"],
 )
 
 
 class Address(Document):
 
-    street = Text(fields={'raw': Keyword()})
+    street = Text(fields={"raw": Keyword()})
     house_number = Keyword()
-    zip_code = Text(fields={'raw': Keyword()})
+    zip_code = Text(fields={"raw": Keyword()})
     city = Nested(
         properties={
-            'name': Text(
+            "name": Text(
                 analyzer=html_strip,
-                fields={
-                    'raw': Keyword(),
-                    'country': Nested(
-                        properties={
-                            'name': Text(
-                                analyzer=html_strip,
-                                fields={
-                                    'raw': Keyword(),
-                                }
-                            )
-                        }
+                fields={"raw": Keyword()},
+            ),
+            "country": Nested(
+                properties={
+                    "name": Text(
+                        analyzer=html_strip,
+                        fields={
+                            "raw": Keyword(),
+                        },
                     )
                 }
-            )
+            ),
         }
     )
 
     class Index:
         name = ADDRESS_ADDRESS_DOCUMENT_NAME
         settings = {
-            'number_of_shards': 1,
-            'number_of_replicas': 1,
-            'blocks': {'read_only_allow_delete': None},
+            "number_of_shards": 1,
+            "number_of_replicas": 1,
+            "blocks": {"read_only_allow_delete": None},
         }
 
 

--- a/examples/search_index/documents/post.py
+++ b/examples/search_index/documents/post.py
@@ -39,9 +39,14 @@ html_strip = analyzer(
     char_filter=["html_strip"]
 )
 
+class CommentAuthor(InnerDoc):
+    name = Text(fields={'raw': Keyword()})
+    age = Integer()
+
 
 class Comment(InnerDoc):
-    author = Text(fields={'raw': Keyword()})
+    author = Nested(CommentAuthor)
+    # author = Text(fields={'raw': Keyword()})
     tag = Text(fields={'raw': Keyword()})
     content = Text(analyzer='snowball')
     created_at = Date()

--- a/src/graphene_elastic/filter_backends/search/common.py
+++ b/src/graphene_elastic/filter_backends/search/common.py
@@ -1,7 +1,9 @@
-from copy import copy, deepcopy
 import operator
+from copy import copy, deepcopy
+from collections import ChainMap
 
 import graphene
+from graphene.types.field import source_resolver
 import six
 
 from elasticsearch_dsl.query import Q
@@ -11,6 +13,7 @@ from ..base import BaseBackend
 from ...constants import (
     DYNAMIC_CLASS_NAME_PREFIX,
     ALL,
+    FIELD,
     VALUE,
     BOOST,
 )
@@ -33,14 +36,30 @@ class SearchFilterBackend(BaseBackend):
         """Search filter fields."""
         search_fields = getattr(
             self.connection_field.type._meta.node._meta,
-            'filter_backend_options',
-            {}
-        ).get('search_fields', {})
+            "filter_backend_options",
+            {},
+        ).get("search_fields", {})
         return deepcopy(search_fields)
+
+    @property
+    def search_nested_fields(self):
+        """Search nested filter fields."""
+        search_nested_fields = getattr(
+            self.connection_field.type._meta.node._meta,
+            "filter_backend_options",
+            {},
+        ).get("search_nested_fields", {})
+        return deepcopy(search_nested_fields)
 
     @property
     def search_args_mapping(self):
         return {field: field for field, value in self.search_fields.items()}
+
+    @property
+    def nested_search_args_mapping(self):
+        return {
+            field: field for field, value in self.search_nested_fields.items()
+        }
 
     def field_belongs_to(self, field_name):
         """Check if given filter field belongs to the backend.
@@ -48,7 +67,10 @@ class SearchFilterBackend(BaseBackend):
         :param field_name:
         :return:
         """
-        return field_name in self.search_fields
+        return (
+            field_name in self.search_fields
+            or field_name in self.search_nested_fields
+        )
 
     def get_backend_default_query_fields_params(self):
         """Get backend default filter params.
@@ -58,27 +80,159 @@ class SearchFilterBackend(BaseBackend):
         """
         return {ALL: graphene.String()}
 
+    def get_search_nested_fields_tree(self, start=None, value=None):
+        """
+        We got a prepared nested fields ,
+
+        {
+            'country': {
+                'path': 'country',
+                'fields': [
+                    {
+                        'name': {'boost': 2}
+                    }
+                ]
+            },
+            'city': {
+                'path': 'country.city',
+                'fields': [
+                    {
+                        'name': {'boost': 2}
+                    }
+                ]
+            }
+        }
+
+        Then we should turn it to
+
+        {
+            'country': {
+                'name': {},   # {} or None represents no more leaves downside.
+                'city': {
+                    'name': {}
+                }
+            }
+        }
+
+
+        """
+        source = self.search_nested_fields
+        path_field_mapping = {
+            option["path"]: field for field, option in source.items()
+        }
+        tree = {}
+
+        for field, option in source.items():
+            if start and not option["path"].startswith(start):
+                continue
+
+            splited_path = option["path"].split(".")
+            inserted = False
+            node = {}
+            for f in option.get("fields", []):
+                if isinstance(f, dict):
+                    node.update({list(f.keys())[0]: deepcopy(value)})
+                elif isinstance(f, six.string_types):
+                    node.update({f: deepcopy(value)})
+
+            # Find sub path item and insert it inside this node
+            for _path, _field in path_field_mapping.items():
+                _splited_path = _path.split(".")
+                if (
+                    _path.startswith(option["path"])
+                    and len(_splited_path) - len(splited_path) == 1
+                    and _field in tree
+                ):
+                    node.update({_field: tree.pop(_field)})
+
+            # Find item which contains this node and put this node inside it.
+            for _path, _field in path_field_mapping.items():
+                _splited_path = _path.split(".")
+                if (
+                    option["path"].startswith(_path)
+                    and len(splited_path) - len(_splited_path) > 0
+                ):
+                    # Note: because we don't sure whether whole path was built over, we should traverse the tree
+                    # and find the proper place to put this node inside it.
+                    t = tree
+                    for __splited in splited_path[:-1]:
+                        if __splited in t:
+                            t = t[__splited]
+
+                    if t != tree:
+                        t.update({field: node})
+                        inserted = True
+                        break
+
+            if not inserted:  # no other node can take this node.
+                tree.update({field: node})
+
+        return tree
+
     def get_field_type(self, field_name, field_value, base_field_type):
         """Get field type.
 
         :return:
+
+        TODO: required
         """
-        params = {
-            VALUE: base_field_type,  # Value to search on. Required.
-            BOOST: graphene.Int(),  # Boost the given field with. Optional.
-        }
-        return graphene.Argument(
-            type(
-                "{}{}{}{}".format(
-                    DYNAMIC_CLASS_NAME_PREFIX,
-                    to_pascal_case(self.prefix),
-                    self.connection_field.type.__name__,
-                    to_pascal_case(field_name)
-                ),
-                (graphene.InputObjectType,),
-                params,
+
+        nested_input_count = 0
+
+        def get_graphene_argument_type(name, params):
+            nonlocal nested_input_count
+            nested_input_count += 1
+            return graphene.Argument(
+                type(
+                    "{}{}{}{}{}".format(
+                        DYNAMIC_CLASS_NAME_PREFIX,
+                        to_pascal_case(self.prefix),
+                        self.connection_field.type.__name__,
+                        to_pascal_case(name),
+                        str(nested_input_count),
+                    ),
+                    (graphene.InputObjectType,),
+                    params,
+                )
             )
-        )
+
+        def dfs(root, root_field_type):
+            ret = {}
+
+            for name, node in root.items():
+                if isinstance(node, dict):
+                    params = self.get_backend_default_query_fields_params()
+                    params.update(
+                        dfs(node, root_field_type._meta.fields.get(name))
+                    )
+                    ret.update({name: get_graphene_argument_type(name, params)})
+                elif not node:
+                    if hasattr(root_field_type, "_meta"):
+                        fields = root_field_type._meta.fields
+                    else:
+                        fields = root_field_type._type._of_type._meta.fields
+                    print(name, fields.get(name))
+                    params = {
+                        VALUE: fields.get(name),
+                        BOOST: graphene.Int(),
+                    }
+                    ret.update({name: get_graphene_argument_type(name, params)})
+
+            return ret
+
+        if field_name in self.search_fields:
+            params = {
+                VALUE: base_field_type,  # Value to search on. Required.
+                BOOST: graphene.Int(),  # Boost the given field with. Optional.
+            }
+            return get_graphene_argument_type(field_name, params)
+
+        elif field_name in self.search_nested_fields:
+            params = self.get_backend_default_query_fields_params()
+            tree = self.get_search_nested_fields_tree().get(field_name)
+            params.update(dfs(tree, base_field_type))
+
+            return get_graphene_argument_type(field_name, params)
 
     def prepare_search_fields(self):
         """Prepare search fields.
@@ -89,6 +243,7 @@ class SearchFilterBackend(BaseBackend):
                 'title': {'boost': 4, 'field': 'title.raw'},
                 'content': {'boost': 2},
                 'category': None,
+                'comments': None
             }
 
         We shall finally have:
@@ -148,16 +303,97 @@ class SearchFilterBackend(BaseBackend):
             # have the following:
             #
             if options is None or isinstance(options, six.string_types):
-                filter_fields.update(
-                    {
-                        field: {"field": options or field}
-                    }
-                )
+                filter_fields.update({field: {"field": options or field}})
             elif "field" not in options:
                 filter_fields.update({field: options})
                 filter_fields[field]["field"] = field
             else:
                 filter_fields.update({field: options})
+
+        return filter_fields
+
+    def prepare_search_nested_fields(self):
+        """Prepare search fields.
+
+        Possible structures:
+
+        Type1
+            search_nested_fields = {
+                'comments': {
+                    'path'; 'comments',
+                    'fields': [
+                        {'author': {'boost': 4}},
+                        {'tag': {'boost': 2}},
+                    ]
+                }
+            }
+        Type2
+            search_nested_fields = {
+                'comments: {
+                    'path'; 'comments',
+                    'fields': ['author', 'tag']
+                }
+            }
+
+        We shall finally have:
+
+            search_nested_fields = {
+                'comments': {
+                    'path': 'comments',
+                    'fields': {
+                        {'author': {'boost': 4}},
+                        {'tag': {'boost': 2}}
+                    }
+                }
+            }
+
+        Sample query would be:
+
+            {
+              allPostDocuments(search:{query:"Another"}) {
+                pageInfo {
+                  startCursor
+                  endCursor
+                  hasNextPage
+                  hasPreviousPage
+                }
+                edges {
+                  cursor
+                  node {
+                    category
+                    title
+                    content
+                    numViews
+                  }
+                }
+              }
+            }
+
+
+        :return: Filtering options.
+        :rtype: dict
+        """
+        filter_args = dict(self.args).get(self.prefix)
+        if not filter_args:
+            return {}
+
+        filter_fields = {}
+        search_nested_fields = self.search_nested_fields
+        # {'query': '', 'title': {'query': '', 'boost': 1}}
+        for field, _ in self.nested_search_args_mapping.items():
+            filter_fields.update({field: {}})
+            options = deepcopy(search_nested_fields.get(field, {}))
+            if "fields" not in options:
+                options["fields"] = []
+
+            fields = []
+            for _field in options["fields"]:
+                if isinstance(_field, six.string_types):
+                    fields.append({_field: {"field": _field}})
+                elif isinstance(_field, dict):
+                    fields.append(_field)
+            options["fields"] = fields
+            filter_fields.update({field: options})
 
         return filter_fields
 
@@ -244,8 +480,10 @@ class SearchFilterBackend(BaseBackend):
         _queries = []
         for search_field, value in all_query_params.items():
             if search_field == ALL:
-                for field_name_param, field_name \
-                        in self.search_args_mapping.items():
+                for (
+                    field_name_param,
+                    field_name,
+                ) in self.search_args_mapping.items():
                     field_options = copy(search_fields[field_name])
                     field = field_options.pop("field", field_name)
 
@@ -280,79 +518,123 @@ class SearchFilterBackend(BaseBackend):
 
         return _queries
 
-    # def construct_nested_search(self):
-    #     """Construct nested search.
-    #
-    #     We have to deal with two types of structures:
-    #
-    #     Type 1:
-    #
-    #     >>> search_nested_fields = {
-    #     >>>     'country': {
-    #     >>>         'path': 'country',
-    #     >>>         'fields': ['name'],
-    #     >>>     },
-    #     >>>     'city': {
-    #     >>>         'path': 'country.city',
-    #     >>>         'fields': ['name'],
-    #     >>>     },
-    #     >>> }
-    #
-    #     Type 2:
-    #
-    #     >>> search_nested_fields = {
-    #     >>>     'country': {
-    #     >>>         'path': 'country',
-    #     >>>         'fields': [{'name': {'boost': 2}}]
-    #     >>>     },
-    #     >>>     'city': {
-    #     >>>         'path': 'country.city',
-    #     >>>         'fields': [{'name': {'boost': 2}}]
-    #     >>>     },
-    #     >>> }
-    #
-    #     :return: Updated queryset.
-    #     :rtype: elasticsearch_dsl.search.Search
-    #     """
-    #     if (
-    #         not hasattr(self, "search_nested_fields")
-    #         or not self.search_nested_fields
-    #     ):
-    #         return []
-    #
-    #     # TODO: Support query boosting
-    #
-    #     query_params = self.prepare_search_fields()
-    #     __queries = []
-    #     for search_term in query_params:
-    #         for label, options in self.search_nested_fields.items():
-    #             queries = []
-    #             path = options.get("path")
-    #
-    #             for _field in options.get("fields", []):
-    #
-    #                 # In case if we deal with structure 2
-    #                 if isinstance(_field, dict):
-    #                     # TODO: take options (such as boost) into
-    #                     # consideration
-    #                     field = "{}.{}".format(path, _field["name"])
-    #                 # In case if we deal with structure 1
-    #                 else:
-    #                     field = "{}.{}".format(path, _field)
-    #
-    #                 field_kwargs = {field: search_term}
-    #
-    #                 queries.append(Q("match", **field_kwargs))
-    #
-    #             __queries.append(
-    #                 Q(
-    #                     "nested",
-    #                     path=path,
-    #                     query=six.moves.reduce(operator.or_, queries),
-    #                 )
-    #             )
-    #
-    #     return __queries
+    def construct_nested_search(self):
+        """Construct nested search.
+
+        We have to deal with two types of structures:
+
+        Type 1:
+
+        >>> search_nested_fields = {
+        >>>     'country': {
+        >>>         'path': 'country',
+        >>>         'fields': ['name'],
+        >>>     },
+        >>>     'city': {
+        >>>         'path': 'country.city',
+        >>>         'fields': ['name'],
+        >>>     },
+        >>> }
+
+        Type 2:
+
+        >>> search_nested_fields = {
+        >>>     'country': {
+        >>>         'path': 'country',
+        >>>         'fields': [{'name': {'boost': 2}}]
+        >>>     },
+        >>>     'city': {
+        >>>         'path': 'country.city',
+        >>>         'fields': [{'name': {'boost': 2}}]
+        >>>     },
+        >>> }
+
+
+        field_kwargs = {field: search_term}
+
+        queries.append(Q("match", **field_kwargs))
+
+        __queries.append(
+            Q(
+                "nested",
+                path=path,
+                query=six.moves.reduce(operator.or_, queries),
+            )
+        )
+
+        :return: Updated queryset.
+        :rtype: elasticsearch_dsl.search.Search
+        """
+        if (
+            not hasattr(self, "search_nested_fields")
+            or not self.search_nested_fields
+        ):
+            return []
+
+        search_fields = self.prepare_search_nested_fields()
+        all_query_params = {
+            search_field: search_terms
+            for search_field, search_terms in self.get_all_query_params().items()
+            if search_field in search_fields
+        }
+
+        def recursive_construct_search(
+            query_params, current_search=None, searched_path=None
+        ):
+            _queries = []
+            for search_field, search_terms in query_params.items():
+                if search_field in search_fields:
+                    # another nested field
+                    r = recursive_construct_search(
+                        search_terms,
+                        current_search=search_field,
+                        searched_path=search_fields[search_field]["path"],
+                    )
+                    _queries.append(
+                        Q(
+                            "nested",
+                            path=search_fields[search_field]["path"],
+                            query=six.moves.reduce(operator.or_, r),
+                        )
+                    )
+                elif search_field == ALL:
+                    # query all fields downside
+                    search_terms = self.get_search_nested_fields_tree(
+                        start=searched_path, value={VALUE: search_terms}
+                    )
+                    r = recursive_construct_search(
+                        search_terms[current_search],
+                        current_search=current_search,
+                        searched_path=searched_path,
+                    )
+                    _queries.append(
+                        Q(
+                            "nested",
+                            path=search_fields[current_search]["path"],
+                            query=six.moves.reduce(operator.or_, r),
+                        )
+                    )
+                else:
+                    # normal field in a nested field
+                    path = search_fields[current_search]["path"]
+                    field_option = deepcopy(
+                        next(
+                            field[search_field]
+                            for field in search_fields[current_search]["fields"]
+                            if list(field.keys())[0] == search_field
+                        )
+                    )
+                    field = "{}.{}".format(path, field_option.pop("field"))
+                    query = search_terms.pop(VALUE)
+                    field_kwargs = {field: {"query": query}}
+                    if field_option:
+                        field_kwargs[field].update(field_option)
+
+                    _queries.append(Q("match", **field_kwargs))
+            return _queries
+
+        queries = recursive_construct_search(all_query_params, None)
+        return queries
 
     def filter(self, queryset):
         """Filter.
@@ -366,10 +648,12 @@ class SearchFilterBackend(BaseBackend):
         if _search:
             _queries.extend(_search)
 
-        # _nested_search = self.construct_nested_search()
-        # if _nested_search:
-        #     _queries.extend(_nested_search)
+        _nested_search = self.construct_nested_search()
+        if _nested_search:
+            _queries.extend(_nested_search)
 
         if _queries:
             queryset = queryset.query("bool", should=_queries)
+
+        print(queryset.to_dict())
         return queryset

--- a/src/graphene_elastic/filter_backends/search/query_backends/nested.py
+++ b/src/graphene_elastic/filter_backends/search/query_backends/nested.py
@@ -156,4 +156,4 @@ class NestedQueryBackend(BaseSearchQueryBackend):
                     )
                 )
 
-        return __queries
+        return _queries

--- a/src/graphene_elastic/tests/test_search_backend.py
+++ b/src/graphene_elastic/tests/test_search_backend.py
@@ -161,7 +161,7 @@ class SearchBackendElasticTestCase(BaseGrapheneElasticTestCase):
         tests.
         """
         self._test_search_content()
-        # self._test_search_nested_tag()
+        self._test_search_nested_tag()
 
 
 class CompoundSearchBackendElasticTestCase(SearchBackendElasticTestCase):

--- a/src/graphene_elastic/tests/test_search_backend.py
+++ b/src/graphene_elastic/tests/test_search_backend.py
@@ -52,19 +52,14 @@ class SearchBackendElasticTestCase(BaseGrapheneElasticTestCase):
         # for _post in self.other_posts:
         #     _post.save()
 
-        self.python="Python"
-        self.num_python_posts = 20
-        self.python_posts = factories.PostFactory.create_batch(
-            self.num_python_posts
+        self.unique_term="Graphene"
+        self.num_nested_posts = 20
+        self.nested_posts = factories.PostFactory.create_batch(
+            self.num_nested_posts
         )
-        for _post in self.python_posts:
-            _post.add_comments(
-                author=self.faker.name(),
-                tag=self.python,
-                content="{} {}".format(
-                    self.faker.paragraph(),
-                    self.python
-                )
+        for _post in self.nested_posts:
+            _post.comments=factories.CommentFactory.create(
+                tag=self.unique_term,
             )
             _post.save()
 
@@ -86,7 +81,9 @@ class SearchBackendElasticTestCase(BaseGrapheneElasticTestCase):
                 category
                 title
                 comments{
-                    author
+                    author{
+                        name
+                    }
                     content
                     createdAt
                 }
@@ -103,36 +100,28 @@ class SearchBackendElasticTestCase(BaseGrapheneElasticTestCase):
             query
         )
 
-    def _test_search_nested_content(self):
-        """Test search content in nested field `comments`
+    def _test_search_nested_tag(self):
+        """Test search tag in nested field `comments`
         
         :return:
         """
 
-        # Covering all field lookups `search:{comments:{query:"Python"}}`
+        # Covering all field lookups `search:{comments:{query:"Graphene"}}`
         with self.subTest('Test search content in nested field `comments'
                           'on term "Python"'):
             self.__test_search_content(
-                '{comments:{%s: "%s"}}' % (ALL, self.term_python),
-                self.num_python_posts
+                '{comments:{%s: "%s"}}' % (ALL, self.unique_term),
+                self.num_nested_posts
             )
         
-        # Covering specific field lookups `search:{comments:{content:{value: "Python"}}}`
+        # Covering specific field lookups `search:{comments:{tag:{value: "Graphene"}}}`
         with self.subTest('Test search content in nested field `comments`'
                           'on term "Python"'):
             self.__test_search_content(
-                '{comments:{content: {%s: "%s"} } }' % (VALUE, self.term_python),
-                self.num_python_posts
+                '{comments:{tag: {%s: "%s"} } }' % (VALUE, self.unique_term),
+                self.num_nested_posts
             )
 
-        # Test boost support
-        with self.subTest('Test search content in nested field `comments`'
-                          'on term "Python"'):
-            self.__test_search_content(
-                '{comments:{content: {%s: "%s", boost: %d} } }' % (VALUE, self.term_python, 4),
-                self.num_python_posts
-            )
-                        
 
     def _test_search_content(self):
         """"Test search content.
@@ -172,7 +161,7 @@ class SearchBackendElasticTestCase(BaseGrapheneElasticTestCase):
         tests.
         """
         self._test_search_content()
-        self._test_search_nested_content()
+        # self._test_search_nested_tag()
 
 
 class CompoundSearchBackendElasticTestCase(SearchBackendElasticTestCase):


### PR DESCRIPTION
Added nested search support.

```graphql
{
  allPostDocuments(search: {comments: {query:"Python", tag:{value: "MongoDB"}}}) {
    edges {
      node {
        id
        comments {
          author{
            age
            name
          }
          tag
          content
          createdAt
        }
      }
    }
  }
}
```
The final query will be this. I just combine input with configured, so there will be some duplicated query.
```json
{
  "query": {
    "bool": {
      "should": [
        {
          "nested": {
            "path": "comments.author",
            "query": {
              "match": {
                "comments.author.name.raw": { "query": "Python", "boost": 2 }
              }
            }
          }
        },
        {
          "nested": {
            "path": "comments",
            "query": {
              "bool": {
                "should": [
                  { "match": { "comments.tag": { "query": "MongoDB" } } },
                  {
                    "match": {
                      "comments.content.raw": { "query": "Python", "boost": 3 }
                    }
                  }
                ]
              }
            }
          }
        },
        {
          "nested": {
            "path": "comments",
            "query": { "match": { "comments.tag": { "query": "MongoDB" } } }
          }
        }
      ]
    }
  }
}

```

Some problems:
1. Each InputObjectType needs a unique name. I just put a auto-incremented number at the end of their names.