### PR TITLE
Fix typo in setup.py metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         "elasticsearch": [
             "elasticsearch>=6.0",
-            "elasticsearch-dsl>=6.0<8.0",
+            "elasticsearch-dsl>=6.0,<8.0",
         ],
         "opensearch": [
             "opensearch-py",


### PR DESCRIPTION
Requires expressions are comma-delimited, the PDM package manager rejects v0.8 because the metadata section is invalid.